### PR TITLE
Move client-only initializer to safe place.

### DIFF
--- a/src/main/java/landmaster/plustic/modifiers/armor/JetpackPancakeHippos.java
+++ b/src/main/java/landmaster/plustic/modifiers/armor/JetpackPancakeHippos.java
@@ -7,7 +7,6 @@ import java.util.*;
 import java.util.function.*;
 import java.util.stream.*;
 
-import net.minecraftforge.client.settings.KeyBindingMap;
 import org.lwjgl.opengl.GL11;
 
 import com.google.common.base.Throwables;
@@ -74,6 +73,18 @@ public class JetpackPancakeHippos extends ArmorModifierTrait {
 	static {
 		MinecraftForge.EVENT_BUS.register(JetpackPancakeHippos.class);
 	}
+
+	@SideOnly(Side.CLIENT)
+	private static final class ClientOnly {
+
+		static final Map<KeyBinding, JetpackSettings> keys = new HashMap<>();
+		static {
+			keys.put(KeybindHandler.JETPACK_ENGINE_KEY, JetpackSettings.ENGINE);
+			keys.put(KeybindHandler.JETPACK_HOVER_KEY, JetpackSettings.HOVER);
+			keys.put(KeybindHandler.JETPACK_EHOVER_KEY, JetpackSettings.EHOVER);
+		}
+
+	}
 	
 	public static enum JetpackSettings {
 		ENGINE, HOVER, EHOVER;
@@ -107,14 +118,7 @@ public class JetpackPancakeHippos extends ArmorModifierTrait {
 			}
 		}
 	}
-	
-	private static final Map<KeyBinding, JetpackSettings> keys = new HashMap<>();
-	static {
-		keys.put(KeybindHandler.JETPACK_ENGINE_KEY, JetpackSettings.ENGINE);
-		keys.put(KeybindHandler.JETPACK_HOVER_KEY, JetpackSettings.HOVER);
-		keys.put(KeybindHandler.JETPACK_EHOVER_KEY, JetpackSettings.EHOVER);
-	}
-	
+
 	@SideOnly(Side.CLIENT)
 	@SubscribeEvent
 	public static void onKeyInput(InputEvent.KeyInputEvent event) {
@@ -124,7 +128,7 @@ public class JetpackPancakeHippos extends ArmorModifierTrait {
 		Utils.getModifiers(chestStack).stream()
 		.filter(trait -> trait instanceof JetpackPancakeHippos)
 		.findAny().ifPresent(trait -> {
-			keys.forEach((key, setting) -> {
+			ClientOnly.keys.forEach((key, setting) -> {
 				if (key.isPressed()) {
 					boolean oldState = setting.isOff(chestStack);
 					if (tonius.simplyjetpacks.config.Config.enableStateMessages) {


### PR DESCRIPTION
Fix crashes while initializing in Minecraft Server.

Related crash log:
```
net.minecraftforge.fml.common.LoaderExceptionModCrash: Caught exception from PlusTiC (plustic)
Caused by: java.lang.NoClassDefFoundError: net/minecraft/client/entity/EntityPlayerSP
    at landmaster.plustic.modifiers.armor.JetpackPancakeHippos.<clinit>(JetpackPancakeHippos.java:113)
    at landmaster.plustic.modules.ModuleConArm$SJ.init(ModuleConArm.java:90)
    at landmaster.plustic.modules.ModuleConArm.init(ModuleConArm.java:83)
    at java.lang.Iterable.forEach(Iterable.java:75)
    at landmaster.plustic.PlusTiC.preInit(PlusTiC.java:141)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke(Method.java:498)
    at net.minecraftforge.fml.common.FMLModContainer.handleModStateEvent(FMLModContainer.java:637)
    at sun.reflect.GeneratedMethodAccessor10.invoke(Unknown Source)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke(Method.java:498)
    at com.google.common.eventbus.Subscriber.invokeSubscriberMethod(Subscriber.java:91)
    at com.google.common.eventbus.Subscriber$SynchronizedSubscriber.invokeSubscriberMethod(Subscriber.java:150)
    at com.google.common.eventbus.Subscriber$1.run(Subscriber.java:76)
    at com.google.common.util.concurrent.MoreExecutors$DirectExecutor.execute(MoreExecutors.java:399)
    at com.google.common.eventbus.Subscriber.dispatchEvent(Subscriber.java:71)
    at com.google.common.eventbus.Dispatcher$PerThreadQueuedDispatcher.dispatch(Dispatcher.java:116)
    at com.google.common.eventbus.EventBus.post(EventBus.java:217)
    at net.minecraftforge.fml.common.LoadController.sendEventToModContainer(LoadController.java:219)
    at net.minecraftforge.fml.common.LoadController.propogateStateMessage(LoadController.java:197)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke(Method.java:498)
    at com.google.common.eventbus.Subscriber.invokeSubscriberMethod(Subscriber.java:91)
    at com.google.common.eventbus.Subscriber$SynchronizedSubscriber.invokeSubscriberMethod(Subscriber.java:150)
    at com.google.common.eventbus.Subscriber$1.run(Subscriber.java:76)
    at com.google.common.util.concurrent.MoreExecutors$DirectExecutor.execute(MoreExecutors.java:399)
    at com.google.common.eventbus.Subscriber.dispatchEvent(Subscriber.java:71)
    at com.google.common.eventbus.Dispatcher$PerThreadQueuedDispatcher.dispatch(Dispatcher.java:116)
    at com.google.common.eventbus.EventBus.post(EventBus.java:217)
    at net.minecraftforge.fml.common.LoadController.distributeStateMessage(LoadController.java:136)
    at net.minecraftforge.fml.common.Loader.preinitializeMods(Loader.java:629)
    at net.minecraftforge.fml.server.FMLServerHandler.beginServerLoading(FMLServerHandler.java:99)
    at net.minecraftforge.fml.common.FMLCommonHandler.onServerStart(FMLCommonHandler.java:333)
    at net.minecraft.server.dedicated.DedicatedServer.init(DedicatedServer.java:125)
    at net.minecraft.server.MinecraftServer.run(MinecraftServer.java:486)
    at java.lang.Thread.run(Thread.java:748)
Caused by: java.lang.ClassNotFoundException: net.minecraft.client.entity.EntityPlayerSP
    at net.minecraft.launchwrapper.LaunchClassLoader.findClass(LaunchClassLoader.java:191)
    at java.lang.ClassLoader.loadClass(ClassLoader.java:418)
    at java.lang.ClassLoader.loadClass(ClassLoader.java:351)
    ... 40 more
```