### PR TITLE
Fixed crash with Simply Jetpacks when ConArm isn't installed

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ plugins {
 
 apply plugin: 'net.minecraftforge.gradle.forge'
 
-version = "8.0.5"
+version = "8.0.6"
 group= "landmaster.plustic" // http://maven.apache.org/guides/mini/guide-naming-conventions.html
 archivesBaseName = "plustic"
 

--- a/src/main/java/landmaster/plustic/modules/ModuleConArm.java
+++ b/src/main/java/landmaster/plustic/modules/ModuleConArm.java
@@ -83,7 +83,7 @@ public class ModuleConArm implements IModule {
 
 	@Override
 	public void init2() {
-		if (Config.jetpackConarmModifier && Loader.isModLoaded("simplyjetpacks")) {
+		if (Config.jetpackConarmModifier && Loader.isModLoaded("simplyjetpacks") && Loader.isModLoaded("conarm")) {
 			SJ.init();
 		}
 	}


### PR DESCRIPTION
Simply adds a missing mod loaded check when initializing.